### PR TITLE
Fix a spelling error in manpage

### DIFF
--- a/man/jp2a.1
+++ b/man/jp2a.1
@@ -99,7 +99,7 @@ Write ASCII output to given filename.  To explicitly specify standard output, us
 .TP
 .B \-i \-\-invert
 Invert output image.  If you view a picture with white background, but you are using
-a display with light characters on a dark background, you shoudl invert the image.
+a display with light characters on a dark background, you should invert the image.
 .TP
 .BI \-\-red= ...
 .TP


### PR DESCRIPTION
The word 'should' was fixed.