### PR TITLE
Remove and ignore INSTALL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/jp2a
 stamp-h1
 Doxyfile
 doxygen-doc/
+INSTALL

--- a/INSTALL
+++ b/INSTALL
@@ -1,1 +1,0 @@
-See the README file for building and installation instructions.


### PR DESCRIPTION
The INSTALL file is created automatically by autoreconf command. Consequently, changes in its content should be ignored.
