### PR TITLE
check for number of scanlines read from jpeg to prevent integer underflow

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -702,7 +702,7 @@ void decompress_jpeg(FILE *fp, FILE *fout, error_collector *errors) {
 		init_image(&image, jpg.output_width, jpg.output_height);
 
 		while ( jpg.output_scanline < jpg.output_height ) {
-			jpeg_read_scanlines(&jpg, buffer, 1);
+			if (jpeg_read_scanlines(&jpg, buffer, 1) == 0) continue;
 			process_scanline_jpeg(&jpg, buffer[0], &image);
 			if ( verbose ) print_progress((float) (jpg.output_scanline + 1.0f) / (float) jpg.output_height);
 		}


### PR DESCRIPTION
`jpeg_read_scanlines()` can read less lines that requested in certain conditions ([ref](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/jdapistd.c#L263-L277)). When it returns without reading any rows, the `output_scanline` can be 0 (refer [here](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/dc4a93fab38b42d29b89a533409e012570180e28/jdapistd.c#L299)). When this happens, it can lead to a integer underflow [here](https://github.com/Talinx/jp2a/blob/master/src/image.c#L446).

This patch adds check for the return value of `jpeg_read_scanlines()` and in case the return value is 0, it just skips that loop and continues.